### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/test.py
+++ b/test.py
@@ -11,6 +11,7 @@
 #  [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
 #
 
+from __future__ import print_function
 import sys
 import os
 import glob
@@ -24,11 +25,11 @@ from apiclient import apiclient
 
 def runTests(testFileSearch):
     for testFilePath in glob.glob(testFileSearch):
-        print 'Running tests from: ' + testFilePath
+        print('Running tests from: ' + testFilePath)
         with open(testFilePath) as testFile:
             testData = json.load(testFile, object_pairs_hook = collections.OrderedDict)
             for testSetName in testData:
-                print testSetName + ':'
+                print(testSetName + ':')
                 testSet = testData[testSetName]
                 vars = testSet['variables']
                 for test in testSet['testcases']:
@@ -37,31 +38,31 @@ def runTests(testFileSearch):
                         template = uritemplate.URITemplate(test[0])
                     except Exception as e:
                         if (expectedResult):
-                            print '* FAIL: "' + test[0] + '" got: None, expected "' + expectedResult + '"'
+                            print('* FAIL: "' + test[0] + '" got: None, expected "' + expectedResult + '"')
                         else:
-                            print '  PASS: "' + test[0] + '" == None'
+                            print('  PASS: "' + test[0] + '" == None')
                         continue
                     
                     result = template.expand(**vars)
                     if (isinstance(expectedResult, basestring)):
                         if (expectedResult != result):
-                            print '* FAIL: "' + test[0] + '" got: "' + unicode(result) + '", expected "' + expectedResult + '"'
+                            print('* FAIL: "' + test[0] + '" got: "' + unicode(result) + '", expected "' + expectedResult + '"')
                             continue
                     elif (isinstance(expectedResult, list)):
                         for possibleResult in expectedResult:
                             if (possibleResult == result):
                                 break
                         else:
-                            print '* FAIL: "' + test[0] + '" got: "' + unicode(result) + '", expected:'
-                            print " or\n".join(['    "' + possibleResult + '"' for possibleResult in expectedResult])
+                            print('* FAIL: "' + test[0] + '" got: "' + unicode(result) + '", expected:')
+                            print(" or\n".join(['    "' + possibleResult + '"' for possibleResult in expectedResult]))
                             continue
                     elif (not expectedResult):
                         if (result):
-                            print '* FAIL "' + test[0] + '" got: "' + unicode(result) + '", expected None'
+                            print('* FAIL "' + test[0] + '" got: "' + unicode(result) + '", expected None')
                             continue
                     else:
-                        print '** Unknown expected result type: ' + repr(expectedResult)
-                    print '  PASS: "' + test[0] + '" == "' + result + '"'
+                        print('** Unknown expected result type: ' + repr(expectedResult))
+                    print('  PASS: "' + test[0] + '" == "' + result + '"')
 
 def debugHook(type, value, tb):
     if hasattr(sys, 'ps1') or not sys.stderr.isatty():
@@ -72,7 +73,7 @@ def debugHook(type, value, tb):
         import traceback, pdb
         # we are NOT in interactive mode, print the exception...
         traceback.print_exception(type, value, tb)
-        print
+        print()
         # ...then start the debugger in post-mortem mode.
         pdb.pm()
 
@@ -88,18 +89,18 @@ if __name__ == "__main__":      # called from the command line
 
 
     github = apiclient.APIClient('https://api.github.com/', version = 'vnd.github.beta')
-    print github.get('user_url', user = 'plinss').data
+    print(github.get('user_url', user = 'plinss').data)
 
 #    shepherd = apiclient.APIClient('https://api.csswg.org/shepherd/', version = 'vnd.csswg.shepherd.v1')
     shepherd = apiclient.APIClient('https://test.linss.com/shepherd/api', version = 'vnd.csswg.shepherd.v1')
-    print shepherd.resourceNames
+    print(shepherd.resourceNames)
     specs = shepherd.resource('specifications')
-    print specs.variables
+    print(specs.variables)
 #    print specs.hints.docs
-    print shepherd.get('specifications', spec = 'compositing-1', anchors = False).data
+    print(shepherd.get('specifications', spec = 'compositing-1', anchors = False).data)
 
     suites = shepherd.resource('test_suites')
-    print suites.variables
-    print shepherd.get('test_suites', spec = 'css-shapes-1').data
+    print(suites.variables)
+    print(shepherd.get('test_suites', spec = 'css-shapes-1').data)
 
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.